### PR TITLE
Deploy IEOMD to platform droplet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,19 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=change-me-postgres-root-password
 
 # =============================================================================
+# DigitalOcean Spaces (shared object storage)
+# =============================================================================
+SPACES_BUCKET=platform-storage
+SPACES_ACCESS_KEY=change-me-spaces-access-key
+SPACES_SECRET_KEY=change-me-spaces-secret-key
+
+# =============================================================================
 # IEOMD
 # =============================================================================
 IEOMD_DB_USER=ieomd
 IEOMD_DB_PASSWORD=change-me-ieomd-password
 IEOMD_DB_NAME=ieomd_db
-IEOMD_CORS_ORIGINS=https://ieomd.com
+IEOMD_CORS_ORIGINS=["https://ieomd.com"]
 
 # =============================================================================
 # Umami

--- a/README.md
+++ b/README.md
@@ -26,8 +26,25 @@ Shared infrastructure for SparkSwarm projects. Manages Docker Compose services, 
 |---------|--------|-------------|
 | Caddy | - | Reverse proxy with automatic HTTPS |
 | Postgres | - | Shared database (internal only) |
-| IEOMD | ieomd.com | Time-locked secret delivery |
+| IEOMD | ieomd.com | Time-locked secret delivery ([repo](https://github.com/richmiles/in-the-event-of-my-death)) |
 | Umami | analytics.sparkswarm.com | Privacy-focused analytics |
+
+## Shared Resources
+
+### Postgres
+Each service gets its own database and user (defined in `init-db.sql`). Services connect via `DATABASE_URL` environment variable.
+
+### DigitalOcean Spaces (Object Storage)
+Shared S3-compatible bucket (`platform-storage`) for file storage. Services use a prefix to isolate their objects:
+
+| Service | Prefix | Example Key |
+|---------|--------|-------------|
+| IEOMD | `ieomd/` | `ieomd/attachments/{uuid}` |
+
+Configure in `.env`:
+- `SPACES_BUCKET` - Bucket name (default: `platform-storage`)
+- `SPACES_ACCESS_KEY` - DigitalOcean Spaces access key
+- `SPACES_SECRET_KEY` - DigitalOcean Spaces secret key
 
 ## Quick Start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,15 @@ services:
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://${IEOMD_DB_USER:-ieomd}:${IEOMD_DB_PASSWORD:?Set IEOMD_DB_PASSWORD in .env}@postgres:5432/${IEOMD_DB_NAME:-ieomd_db}
-      CORS_ORIGINS: ${IEOMD_CORS_ORIGINS:-https://ieomd.com}
+      CORS_ORIGINS: ${IEOMD_CORS_ORIGINS:-["https://ieomd.com"]}
+      # Object Storage (shared bucket with project prefix)
+      OBJECT_STORAGE_ENABLED: "true"
+      OBJECT_STORAGE_ENDPOINT: https://nyc3.digitaloceanspaces.com
+      OBJECT_STORAGE_BUCKET: ${SPACES_BUCKET:-platform-storage}
+      OBJECT_STORAGE_PREFIX: ieomd
+      OBJECT_STORAGE_ACCESS_KEY: ${SPACES_ACCESS_KEY:?Set SPACES_ACCESS_KEY in .env}
+      OBJECT_STORAGE_SECRET_KEY: ${SPACES_SECRET_KEY:?Set SPACES_SECRET_KEY in .env}
+      OBJECT_STORAGE_REGION: nyc3
     networks:
       - internal
     depends_on:


### PR DESCRIPTION
## Summary
- Add DigitalOcean Spaces environment variables to IEOMD service
- Add shared Spaces credentials to .env.example
- Document shared object storage configuration in README

## Changes
- `docker-compose.yml` - Add `OBJECT_STORAGE_*` env vars to IEOMD service
- `.env.example` - Add `SPACES_*` credentials section
- `README.md` - Document shared Postgres and Spaces resources

## Test plan
- [ ] Update `.env` on platform droplet with Spaces credentials
- [ ] Run `docker compose pull && docker compose up -d`
- [ ] Verify IEOMD accessible at https://ieomd.com
- [ ] Test file attachment upload/download

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)