### PR TITLE
Fix: use two-image architecture for IEOMD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,11 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=change-me-postgres-root-password
 
 # =============================================================================
-# DigitalOcean Spaces (shared object storage)
+# DigitalOcean Spaces (shared object storage) - Optional
 # =============================================================================
 SPACES_BUCKET=platform-storage
-SPACES_ACCESS_KEY=change-me-spaces-access-key
-SPACES_SECRET_KEY=change-me-spaces-secret-key
+SPACES_ACCESS_KEY=  # Optional - leave empty to disable object storage
+SPACES_SECRET_KEY=  # Optional - leave empty to disable object storage
 
 # =============================================================================
 # IEOMD
@@ -21,6 +21,8 @@ IEOMD_DB_USER=ieomd
 IEOMD_DB_PASSWORD=change-me-ieomd-password
 IEOMD_DB_NAME=ieomd_db
 IEOMD_CORS_ORIGINS=["https://ieomd.com"]
+IEOMD_IMAGE_TAG=latest  # or sha-xxxxxxx for specific version
+OBJECT_STORAGE_ENABLED=false  # Set to true after configuring Spaces credentials
 
 # =============================================================================
 # Umami

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,6 @@
 # IEOMD - Time-locked secret delivery
 ieomd.com {
-	reverse_proxy ieomd:8000
+	reverse_proxy ieomd:80
 }
 
 www.ieomd.com {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,20 +36,31 @@ services:
       timeout: 5s
       retries: 5
 
-  # IEOMD - Time-locked secret delivery
+  # IEOMD Web - Caddy + static frontend (proxies /api to backend)
   ieomd:
-    image: ghcr.io/richmiles/ieomd:latest
+    image: ghcr.io/richmiles/in-the-event-of-my-death-web:${IEOMD_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    environment:
+      SITE_ADDRESS: ":80"  # Internal HTTP only (platform Caddy handles TLS)
+    networks:
+      - internal
+    depends_on:
+      - backend
+
+  # IEOMD Backend - FastAPI (named "backend" to match IEOMD web Caddyfile)
+  backend:
+    image: ghcr.io/richmiles/in-the-event-of-my-death-backend:${IEOMD_IMAGE_TAG:-latest}
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://${IEOMD_DB_USER:-ieomd}:${IEOMD_DB_PASSWORD:?Set IEOMD_DB_PASSWORD in .env}@postgres:5432/${IEOMD_DB_NAME:-ieomd_db}
       CORS_ORIGINS: ${IEOMD_CORS_ORIGINS:-["https://ieomd.com"]}
       # Object Storage (shared bucket with project prefix)
-      OBJECT_STORAGE_ENABLED: "true"
+      OBJECT_STORAGE_ENABLED: ${OBJECT_STORAGE_ENABLED:-false}
       OBJECT_STORAGE_ENDPOINT: https://nyc3.digitaloceanspaces.com
       OBJECT_STORAGE_BUCKET: ${SPACES_BUCKET:-platform-storage}
       OBJECT_STORAGE_PREFIX: ieomd
-      OBJECT_STORAGE_ACCESS_KEY: ${SPACES_ACCESS_KEY:?Set SPACES_ACCESS_KEY in .env}
-      OBJECT_STORAGE_SECRET_KEY: ${SPACES_SECRET_KEY:?Set SPACES_SECRET_KEY in .env}
+      OBJECT_STORAGE_ACCESS_KEY: ${SPACES_ACCESS_KEY:-}
+      OBJECT_STORAGE_SECRET_KEY: ${SPACES_SECRET_KEY:-}
       OBJECT_STORAGE_REGION: nyc3
     networks:
       - internal


### PR DESCRIPTION
## Summary
IEOMD publishes separate web and backend images, not a single unified image. This PR updates the docker-compose to match the working configuration on the platform droplet.

## Changes
- Split `ieomd` service into `ieomd` (web) + `backend` services
- Update image references to `in-the-event-of-my-death-{web,backend}`
- Make object storage optional (disabled by default)
- Add `IEOMD_IMAGE_TAG` for version pinning
- Update Caddyfile to proxy to `ieomd:80` (web container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)