### PR TITLE
chore: drop swarm.sparkswarm.com vhost and references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This repo manages shared infrastructure for all SparkSwarm projects on a single 
 | postgres | - | 5432 | Shared DB (internal only) |
 | ieomd | ieomd.com | 8000 | IEOMD app (FastAPI serves built SPA + API) |
 | umami | analytics.sparkswarm.com | 3000 | Privacy-focused analytics |
-| spark-swarm | swarm.sparkswarm.com | 8000 | Project dashboard + secrets manager |
+| spark-swarm | sparkswarm.com | 8000 | Project dashboard + secrets manager |
 | synapse | chat.sparkswarm.com | 8008 | Matrix server (ops alerting) - planned |
 | noodle | callofthenoodle.com | 8000 | Bar rating app |
 | human-index | humanindex.io | 8000 | Private recall utility |
@@ -50,17 +50,17 @@ Email standard:
 
 ```bash
 # Store a secret
-curl -X POST https://swarm.sparkswarm.com/api/v1/secrets \
+curl -X POST https://sparkswarm.com/api/v1/secrets \
   -H "X-API-Key: $SPARK_SWARM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "MYAPP_DB_PASSWORD", "value": "secret", "project": "myapp", "environment": "production"}'
 
 # Get a secret
-curl "https://swarm.sparkswarm.com/api/v1/secrets/resolve/MYAPP_DB_PASSWORD?project=myapp&environment=production" \
+curl "https://sparkswarm.com/api/v1/secrets/resolve/MYAPP_DB_PASSWORD?project=myapp&environment=production" \
   -H "X-API-Key: $SPARK_SWARM_API_KEY"
 
 # Export all secrets for a project as .env
-curl "https://swarm.sparkswarm.com/api/v1/secrets/export/dotenv?project=myapp&environment=production" \
+curl "https://sparkswarm.com/api/v1/secrets/export/dotenv?project=myapp&environment=production" \
   -H "X-API-Key: $SPARK_SWARM_API_KEY"
 ```
 
@@ -160,7 +160,7 @@ SparkSwarm Secrets API is the source of truth for production secrets, but servic
 Workflow:
 1) Store/update secrets in SparkSwarm:
 ```bash
-curl -X POST https://swarm.sparkswarm.com/api/v1/secrets \
+curl -X POST https://sparkswarm.com/api/v1/secrets \
   -H "X-API-Key: $SPARK_SWARM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name":"HUMAN_INDEX_DB_PASSWORD","value":"generated-password","project":"human-index","environment":"production"}'
@@ -168,7 +168,7 @@ curl -X POST https://swarm.sparkswarm.com/api/v1/secrets \
 
 2) Export to dotenv (review first):
 ```bash
-curl -s "https://swarm.sparkswarm.com/api/v1/secrets/export/dotenv?project=human-index&environment=production" \
+curl -s "https://sparkswarm.com/api/v1/secrets/export/dotenv?project=human-index&environment=production" \
   -H "X-API-Key: $SPARK_SWARM_API_KEY"
 ```
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -71,12 +71,6 @@ www.sparkswarm.com {
 	redir https://sparkswarm.com{uri} permanent
 }
 
-swarm.sparkswarm.com {
-	encode zstd gzip
-	header /assets/* Cache-Control "public, max-age=31536000, immutable"
-	reverse_proxy spark-swarm:8000
-}
-
 # Esher's Codex - Math curriculum app
 esherscodex.com {
 	encode zstd gzip

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Shared infrastructure for SparkSwarm projects. Manages Docker Compose services, 
 | For Whenever | forwhenever.com | Private messages and files for later ([repo](https://github.com/richmiles/for-whenever)) |
 | Noodle | callofthenoodle.com | Bar rating app |
 | Umami | analytics.sparkswarm.com | Privacy-focused analytics |
-| Spark Swarm | swarm.sparkswarm.com | Project dashboard + secrets manager |
+| Spark Swarm | sparkswarm.com | Project dashboard + secrets manager |
 | Human Index | humanindex.io | Private recall utility (subjects + observations) |
 | Esher's Codex | esherscodex.com | Math curriculum app |
 | richmiles.xyz | richmiles.xyz | Portfolio site + public API |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,7 +227,7 @@ services:
       CORS_ORIGINS: https://esherscodex.com
       COOKIE_NAME: eshers_codex_learner
       COOKIE_MAX_AGE_DAYS: 365
-      SPARK_SWARM_OAUTH_BASE_URL: https://swarm.sparkswarm.com
+      SPARK_SWARM_OAUTH_BASE_URL: https://sparkswarm.com
       SPARK_SWARM_OAUTH_CLIENT_ID: eshers-codex-web
       SPARK_SWARM_OAUTH_CLIENT_SECRET: ${ESHERS_CODEX_SPARK_SWARM_OAUTH_CLIENT_SECRET:?Set ESHERS_CODEX_SPARK_SWARM_OAUTH_CLIENT_SECRET in .env}
       SPARK_SWARM_OAUTH_REDIRECT_URI: https://esherscodex.com/auth/callback


### PR DESCRIPTION
## Summary
- Remove the `swarm.sparkswarm.com` Caddy vhost. `sparkswarm.com` is the canonical domain.
- Update `AGENTS.md`/`README.md` examples and the eshers-codex `SPARK_SWARM_OAUTH_BASE_URL` default in `docker-compose.yml`.

## Deploy plan (coordinated with sibling PRs in spark-swarm, eshers-codex, human-index, etc.)
1. Land this PR + sibling PRs.
2. Flip \`SPARK_SWARM_API_URL=https://sparkswarm.com\` in \`/root/platform-infra/.env\` on the platform droplet.
3. \`./bin/platform prod sync infra --yes\` (delivers updated Caddyfile + docker-compose.yml).
4. \`./bin/platform prod caddy restart --yes --really\` — drops the legacy listener (anything still hitting it 404s).
5. Restart spark-swarm (new WebAuthn defaults — registered passkeys invalidated, users re-enroll).
6. Restart eshers-codex + human-index to pick up new \`SPARK_SWARM_OAUTH_BASE_URL\`.

## Test plan
- [ ] Caddy config validates on the droplet (\`docker compose exec caddy caddy validate --config /etc/caddy/Caddyfile\`)
- [ ] \`https://sparkswarm.com/healthz\` returns 200 after rollout
- [ ] \`https://swarm.sparkswarm.com/healthz\` returns 404 after rollout (vhost removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)