### PR TITLE
ci: add check workflow (compose / Caddyfile / shellcheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      runner_target:
+        description: "Runner target for manual runs"
+        required: true
+        type: choice
+        default: "ubuntu-latest"
+        options:
+          - self-hosted-canary
+          - ubuntu-latest
+
+jobs:
+  check:
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Synthesize .env for compose validation
+        run: |
+          # docker compose config rejects ${VAR} interpolations without a value,
+          # and .env.example drifts behind docker-compose.yml. Generate a stub
+          # value for every ${VAR} referenced by compose so syntax can be checked.
+          grep -oE '\$\{[A-Z_][A-Z_0-9]*' docker-compose.yml \
+            | sort -u \
+            | tr -d '${' \
+            | awk '{print $1"=ci"}' > .env
+
+      - name: Validate docker-compose.yml
+        run: docker compose -f docker-compose.yml config --quiet
+
+      - name: Validate Caddyfile
+        run: |
+          docker run --rm \
+            -v "$PWD/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            caddy:2-alpine \
+            caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+
+      - name: Shellcheck scripts
+        run: shellcheck --severity=error setup.sh scripts/*.sh


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml`: three sanity checks on PR + push-to-main, with the same `runner_target` workflow_dispatch override as `docs-drift.yml`.
- Validates `docker-compose.yml` via `docker compose config`, `Caddyfile` via `caddy:2-alpine` (same image prod uses), and `setup.sh` + `scripts/*.sh` via `shellcheck --severity=error`.
- Fleet-wide CI audit found this was the only active repo without a check workflow.

## Why now

Deploys land via `rsync + ssh docker compose restart`, not via CI promotion. That makes PR-merge the *only* gate before a malformed `Caddyfile` takes down every domain or a broken compose file refuses to start. The README already documents the `docker compose config` check as a manual step (`README.md:138-157`) — this just automates what's already considered best practice here.

## Notes for reviewers

- **`.env.example` has drifted** — 35 vars referenced in `docker-compose.yml` are missing from it. To avoid blocking this PR on that cleanup, the workflow synthesizes a stub `.env` directly from compose's `${VAR}` references. Worth fixing `.env.example` in a follow-up so the synthetic-env hack can be removed.
- **Shellcheck severity set to `error`** — existing scripts have a few SC2155 / SC2295 warnings (`scripts/db_backup.sh:140`, `scripts/db_backup.sh:180`, `scripts/drift_check.sh:48`). Setting severity to error keeps this baseline tight without dragging in cleanup. Easy to tighten later.

## Test plan

- [x] `docker compose config --quiet` passes locally with the synthesized env
- [x] `caddy:2-alpine caddy validate` reports "Valid configuration" for current `Caddyfile`
- [x] `shellcheck --severity=error setup.sh scripts/*.sh` is green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)