### PR TITLE
chore: bump actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -19,8 +19,8 @@ jobs:
   docs_drift:
     runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Docs drift (infra)


### PR DESCRIPTION
## Summary
- GitHub forces Node 24 on JS actions starting **2026-06-16**; Node 20 is removed **2026-09-16**.
- Bumps action versions in this repo's workflows to their Node-24-compatible releases.
- Where an action has no Node-24 release yet, sets workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` so we test compat now.

## Bumps in this PR
- `actions/checkout@v4` -> `@v6` in `.github/workflows/docs-drift.yml`
- `actions/setup-python@v5` -> `@v6` in `.github/workflows/docs-drift.yml`

No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var was needed — both actions used here have Node-24 releases.

## Test plan
- [ ] CI passes on this branch (deprecation warnings on Node 20 actions should be gone).
- [ ] No workflow-specific behavior change beyond the runtime bump.

Part of the fleet-wide Node 24 sweep (follow-up to human-index PR #150 and bullshit-or-fit PR #12).