### PR TITLE
docs: retire BTCPay + mark old runner section obsolete

### DIFF
--- a/WHEN_SOMETHING_BREAKS.md
+++ b/WHEN_SOMETHING_BREAKS.md
@@ -167,11 +167,16 @@ If a deployment broke something:
 ### What needs immediate attention
 
 - **Site completely down** - Users can't access secrets
-- **Payment failures** - BTCPay not processing payments
 - **Data loss risk** - Postgres issues, disk full
 - **Security incidents** - Unusual access patterns, credential exposure
 
 ## CI Runners (do-1gb-runner-main)
+
+> ⚠️ **OBSOLETE as of 2026-06-14.** The droplet `167.172.224.151` was repurposed as the
+> **platform-ci** worker (resized to 2 GB; GitHub-Actions-free build+deploy on merge) — see
+> `ci/README.md` and `docs/cicd-redesign.md`. The GitHub Actions org runner below is dead and
+> not being revived (D2). The recovery steps in this section are historical; for the current
+> worker use `systemctl status platform-ci` and `/srv/platform-ci/logs/worker.log`.
 
 Self-hosted GitHub Actions runners live on a separate droplet (`167.172.224.151`), not the production platform droplet. There is one **org-level** runner — `actions.runner.miles-automation.do-1gb-org-runner` — that services every `miles-automation/*` repo via the `do-1gb-canary` label. (The older per-repo `actions.runner.richmiles-*` services from `setup-runners.sh` are obsolete.)
 
@@ -257,4 +262,3 @@ Mitigations (in increasing order of disruption):
 
 - DigitalOcean Status: https://status.digitalocean.com
 - Caddy Issues: Check https://github.com/caddyserver/caddy/issues
-- BTCPay Issues: Check https://github.com/btcpayserver/btcpayserver/issues

--- a/docs/SPARKSWARM_BRAND.md
+++ b/docs/SPARKSWARM_BRAND.md
@@ -8,7 +8,7 @@ SparkSwarm is the shared infrastructure namespace for Rich Miles' projects. It p
 |--------|---------|---------|
 | analytics.sparkswarm.com | Umami | Privacy-focused analytics |
 | chat.sparkswarm.com | Matrix/Synapse | Operational alerting |
-| pay.sparkswarm.com | BTCPay Server | Bitcoin payments |
+| ci.sparkswarm.com | platform-ci | GitHub-Actions-free CI/CD webhook worker |
 
 ## What Projects Get
 
@@ -23,11 +23,6 @@ Projects hosted on SparkSwarm infrastructure automatically inherit:
 - Error notifications via Matrix
 - Operational alerts for rate limits, scheduler failures
 - Single ops room for all projects
-
-**Payments**
-- Bitcoin/Lightning payment processing via BTCPay
-- No payment processor intermediaries
-- Webhook integration for payment confirmation
 
 ## Projects Using SparkSwarm
 
@@ -50,7 +45,6 @@ Projects don't need to mention SparkSwarm to users. The infrastructure is invisi
 2. Add domain routing to `Caddyfile`
 3. Configure analytics: add Umami script with new website ID
 4. Configure alerting: add Matrix room/token to project config
-5. Configure payments (if needed): create BTCPay store and webhook
 
 ## Infrastructure Details
 


### PR DESCRIPTION
Cleanup after the BTCPay decommission (2026-06-14) and platform-ci repurpose. Drops BTCPay from SPARKSWARM_BRAND + WHEN_SOMETHING_BREAKS; banners the obsolete GHA runner section (box is platform-ci now). 🤖 Generated with Claude Code