### PR TITLE
Externalize Postgres to platform-db droplet + point backups at it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@
 # =============================================================================
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=change-me-postgres-root-password
+# Postgres lives on the dedicated platform-db droplet (VPC private IP), not the compose
+# container. POSTGRES_HOST repoints the whole fleet (apps read it via docker-compose); the
+# backup script (scripts/db_backup.sh) dumps from DB_BACKUP_DB_HOST (defaults to the same).
+# Unset/leave as 'postgres' to fall back to the local compose container.
+POSTGRES_HOST=10.108.0.5
 
 # =============================================================================
 # DigitalOcean Spaces (shared object storage) - Optional

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     restart: unless-stopped
     mem_limit: 256m
     environment:
-      DATABASE_URL: postgresql+psycopg2://${IEOMD_DB_USER:-ieomd}:${IEOMD_DB_PASSWORD:?Set IEOMD_DB_PASSWORD in .env}@postgres:5432/${IEOMD_DB_NAME:-ieomd_db}
+      DATABASE_URL: postgresql+psycopg2://${IEOMD_DB_USER:-ieomd}:${IEOMD_DB_PASSWORD:?Set IEOMD_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${IEOMD_DB_NAME:-ieomd_db}
       CORS_ORIGINS: ${IEOMD_CORS_ORIGINS:-["https://ieomd.com"]}
       # Object Storage (shared bucket with project prefix)
       # Prefer IEOMD_OBJECT_STORAGE_ENABLED; OBJECT_STORAGE_ENABLED is supported for backward compatibility.
@@ -102,7 +102,7 @@ services:
     restart: unless-stopped
     mem_limit: 256m
     environment:
-      DATABASE_URL: postgresql+psycopg2://${FOR_WHENEVER_DB_USER:-for_whenever}:${FOR_WHENEVER_DB_PASSWORD:?Set FOR_WHENEVER_DB_PASSWORD in .env}@postgres:5432/${FOR_WHENEVER_DB_NAME:-for_whenever_db}
+      DATABASE_URL: postgresql+psycopg2://${FOR_WHENEVER_DB_USER:-for_whenever}:${FOR_WHENEVER_DB_PASSWORD:?Set FOR_WHENEVER_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${FOR_WHENEVER_DB_NAME:-for_whenever_db}
       CORS_ORIGINS: ${FOR_WHENEVER_CORS_ORIGINS:-["https://forwhenever.com"]}
       OBJECT_STORAGE_ENABLED: ${FOR_WHENEVER_OBJECT_STORAGE_ENABLED:-${OBJECT_STORAGE_ENABLED:-false}}
       OBJECT_STORAGE_ENDPOINT: https://nyc3.digitaloceanspaces.com
@@ -131,7 +131,7 @@ services:
     restart: unless-stopped
     mem_limit: 256m
     environment:
-      DATABASE_URL: postgresql://${UMAMI_DB_USER:-umami}:${UMAMI_DB_PASSWORD:?Set UMAMI_DB_PASSWORD in .env}@postgres:5432/${UMAMI_DB_NAME:-umami_db}
+      DATABASE_URL: postgresql://${UMAMI_DB_USER:-umami}:${UMAMI_DB_PASSWORD:?Set UMAMI_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${UMAMI_DB_NAME:-umami_db}
       APP_SECRET: ${UMAMI_APP_SECRET:?Set UMAMI_APP_SECRET in .env}
     networks:
       - internal
@@ -150,7 +150,7 @@ services:
       SYNAPSE_NO_TLS: "yes"
       SYNAPSE_ENABLE_REGISTRATION: "no"
       SYNAPSE_LOG_LEVEL: WARNING
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_PORT: 5432
       POSTGRES_DB: ${SYNAPSE_DB_NAME:-synapse_db}
       POSTGRES_USER: ${SYNAPSE_DB_USER:-synapse}
@@ -169,7 +169,7 @@ services:
     restart: unless-stopped
     mem_limit: 192m
     environment:
-      DATABASE_URL: postgresql+psycopg2://${NOODLE_DB_USER:-noodle}:${NOODLE_DB_PASSWORD:?Set NOODLE_DB_PASSWORD in .env}@postgres:5432/${NOODLE_DB_NAME:-noodle_db}
+      DATABASE_URL: postgresql+psycopg2://${NOODLE_DB_USER:-noodle}:${NOODLE_DB_PASSWORD:?Set NOODLE_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${NOODLE_DB_NAME:-noodle_db}
       ENVIRONMENT: production
     networks:
       - internal
@@ -183,7 +183,7 @@ services:
     restart: unless-stopped
     mem_limit: 256m
     environment:
-      DATABASE_URL: postgresql+psycopg://${HUMAN_INDEX_DB_USER:-human_index}:${HUMAN_INDEX_DB_PASSWORD:?Set HUMAN_INDEX_DB_PASSWORD in .env}@postgres:5432/${HUMAN_INDEX_DB_NAME:-human_index_db}
+      DATABASE_URL: postgresql+psycopg://${HUMAN_INDEX_DB_USER:-human_index}:${HUMAN_INDEX_DB_PASSWORD:?Set HUMAN_INDEX_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${HUMAN_INDEX_DB_NAME:-human_index_db}
       CORS_ORIGINS: ${HUMAN_INDEX_CORS_ORIGINS:-["https://humanindex.io"]}
       ENVIRONMENT: ${HUMAN_INDEX_ENVIRONMENT:-production}
       PUBLIC_BASE_URL: ${HUMAN_INDEX_PUBLIC_BASE_URL:-https://humanindex.io}
@@ -228,8 +228,14 @@ services:
     restart: unless-stopped
     mem_limit: 256m
     environment:
-      DATABASE_URL: postgresql+psycopg://${HUMAN_INDEX_V2_DB_USER:-human_index_v2}:${HUMAN_INDEX_V2_DB_PASSWORD:?Set HUMAN_INDEX_V2_DB_PASSWORD in .env}@postgres:5432/${HUMAN_INDEX_V2_DB_NAME:-human_index_v2}
+      DATABASE_URL: postgresql+psycopg://${HUMAN_INDEX_V2_DB_USER:-human_index_v2}:${HUMAN_INDEX_V2_DB_PASSWORD:?Set HUMAN_INDEX_V2_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${HUMAN_INDEX_V2_DB_NAME:-human_index_v2}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Spark Swarm OAuth (authed iMessage ingest). Empty client creds / seed-sub leave ingest
+      # fail-closed (503/403); the digest + comment SPA endpoints are unaffected.
+      SPARK_SWARM_BASE_URL: ${SPARK_SWARM_BASE_URL:-https://sparkswarm.com}
+      SPARK_SWARM_CLIENT_ID: ${HUMAN_INDEX_V2_SPARK_CLIENT_ID:-}
+      SPARK_SWARM_CLIENT_SECRET: ${HUMAN_INDEX_V2_SPARK_CLIENT_SECRET:-}
+      SEED_USER_SPARK_SUB: ${HUMAN_INDEX_V2_SEED_USER_SPARK_SUB:-}
     networks:
       - internal
     depends_on:
@@ -242,7 +248,7 @@ services:
     restart: unless-stopped
     mem_limit: 192m
     environment:
-      DATABASE_URL: postgresql+psycopg://${ESHERS_CODEX_DB_USER:-eshers_codex}:${ESHERS_CODEX_DB_PASSWORD:?Set ESHERS_CODEX_DB_PASSWORD in .env}@postgres:5432/${ESHERS_CODEX_DB_NAME:-eshers_codex_db}
+      DATABASE_URL: postgresql+psycopg://${ESHERS_CODEX_DB_USER:-eshers_codex}:${ESHERS_CODEX_DB_PASSWORD:?Set ESHERS_CODEX_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${ESHERS_CODEX_DB_NAME:-eshers_codex_db}
       ENVIRONMENT: production
       CONTENT_DIR: /app/content
       CORS_ORIGINS: https://esherscodex.com
@@ -299,13 +305,13 @@ services:
     restart: unless-stopped
     mem_limit: 512m
     environment:
-      DATABASE_URL: postgresql://${SPARK_SWARM_DB_USER:-spark_swarm}:${SPARK_SWARM_DB_PASSWORD:?Set SPARK_SWARM_DB_PASSWORD in .env}@postgres:5432/${SPARK_SWARM_DB_NAME:-spark_swarm_db}
+      DATABASE_URL: postgresql://${SPARK_SWARM_DB_USER:-spark_swarm}:${SPARK_SWARM_DB_PASSWORD:?Set SPARK_SWARM_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${SPARK_SWARM_DB_NAME:-spark_swarm_db}
       AUTO_CREATE_TABLES: "true"
       SPARK_SWARM_MASTER_KEY: ${SPARK_SWARM_MASTER_KEY:?Set SPARK_SWARM_MASTER_KEY in .env}
       SPARK_SWARM_API_KEY: ${SPARK_SWARM_API_KEY:?Set SPARK_SWARM_API_KEY in .env}
       SPARK_SWARM_AUTH_DISABLED: ${SPARK_SWARM_AUTH_DISABLED:-false}
       CANVAS_API_KEY: ${CANVAS_API_KEY:-}
-      UMAMI_DATABASE_URL: postgresql://${UMAMI_DB_USER:-umami}:${UMAMI_DB_PASSWORD:?Set UMAMI_DB_PASSWORD in .env}@postgres:5432/${UMAMI_DB_NAME:-umami_db}
+      UMAMI_DATABASE_URL: postgresql://${UMAMI_DB_USER:-umami}:${UMAMI_DB_PASSWORD:?Set UMAMI_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${UMAMI_DB_NAME:-umami_db}
       UPTIME_STATE_PATH: /data/uptime/state.json
       MATRIX_HOMESERVER_URL: ${MATRIX_HOMESERVER_URL:-}
       MATRIX_ACCESS_TOKEN: ${MATRIX_ACCESS_TOKEN:-}
@@ -424,7 +430,7 @@ services:
     mem_limit: 192m
     command: ["python", "-m", "app.lead_scheduler"]
     environment:
-      DATABASE_URL: postgresql://${SPARK_SWARM_DB_USER:-spark_swarm}:${SPARK_SWARM_DB_PASSWORD:?Set SPARK_SWARM_DB_PASSWORD in .env}@postgres:5432/${SPARK_SWARM_DB_NAME:-spark_swarm_db}
+      DATABASE_URL: postgresql://${SPARK_SWARM_DB_USER:-spark_swarm}:${SPARK_SWARM_DB_PASSWORD:?Set SPARK_SWARM_DB_PASSWORD in .env}@${POSTGRES_HOST:-postgres}:5432/${SPARK_SWARM_DB_NAME:-spark_swarm_db}
       LEADS_WORKER_INTERVAL_SECONDS: ${LEADS_WORKER_INTERVAL_SECONDS:-300}
       MATRIX_HOMESERVER_URL: ${MATRIX_HOMESERVER_URL:-}
       MATRIX_ACCESS_TOKEN: ${MATRIX_ACCESS_TOKEN:-}

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -45,9 +45,15 @@ HEALTH_MAX_AGE_HOURS="${DB_BACKUP_HEALTH_MAX_AGE_HOURS:-25}"
 STATE_FILE="${BACKUP_DIR}/backup_state.env"
 DATABASE_USER="${DB_BACKUP_DATABASE_USER:-${POSTGRES_USER:-postgres}}"
 
-# All databases to back up (derived from init-db.sql).
-# Override with DB_BACKUP_DATABASES (comma-separated) if needed.
-DEFAULT_DATABASES="ieomd_db,umami_db,synapse_db,human_index_db,spark_swarm_db,eshers_codex_db,noodle_db"
+# Postgres now lives on the dedicated platform-db droplet (VPC private IP), not the local
+# compose container — so we dump OVER THE NETWORK with a throwaway pg client container (version
+# pinned to match the server). DB_HOST defaults to platform-db's private IP.
+DB_HOST="${DB_BACKUP_DB_HOST:-10.108.0.5}"
+DB_PORT="${DB_BACKUP_DB_PORT:-5432}"
+PG_CLIENT_IMAGE="${DB_BACKUP_PG_CLIENT_IMAGE:-postgres:18-alpine}"
+
+# All databases to back up. Override with DB_BACKUP_DATABASES (comma-separated) if needed.
+DEFAULT_DATABASES="ieomd_db,for_whenever_db,umami_db,synapse_db,human_index_db,human_index_v2,spark_swarm_db,eshers_codex_db,noodle_db"
 IFS=',' read -ra DATABASES <<< "${DB_BACKUP_DATABASES:-$DEFAULT_DATABASES}"
 
 MATRIX_HOMESERVER_URL="${MATRIX_HOMESERVER_URL:-}"
@@ -211,12 +217,11 @@ backup_single_db() {
   local local_path="${BACKUP_DIR}/${filename}"
   local object_key="${SPACES_PREFIX%/}/${filename}"
 
-  log "starting backup for database=${db_name}"
-  if ! (
-    cd "$COMPOSE_DIR"
-    docker compose -f "$COMPOSE_FILE" exec -T postgres \
-      pg_dump -U "$DATABASE_USER" --no-owner --no-privileges "$db_name"
-  ) | gzip -c >"$tmp_path"; then
+  log "starting backup for database=${db_name} (host=${DB_HOST})"
+  if ! docker run --rm -e PGPASSWORD="${POSTGRES_PASSWORD:-}" "$PG_CLIENT_IMAGE" \
+      pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DATABASE_USER" \
+      --no-owner --no-privileges "$db_name" \
+      | gzip -c >"$tmp_path"; then
     rm -f "$tmp_path"
     log "pg_dump failed for ${db_name}"
     send_matrix_alert "DB backup failed: pg_dump failed for ${db_name}."
@@ -245,6 +250,10 @@ run_backup() {
 
   if [[ -z "$SPACES_BUCKET" || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
     log "SPACES_BUCKET, SPACES_ACCESS_KEY, and SPACES_SECRET_KEY must be set"
+    exit 1
+  fi
+  if [[ -z "${POSTGRES_PASSWORD:-}" ]]; then
+    log "POSTGRES_PASSWORD must be set (network dump from ${DB_HOST} needs it)"
     exit 1
   fi
 


### PR DESCRIPTION
Moves the fleet's Postgres off the shared platform droplet's compose container onto a dedicated $6 `platform-db` droplet (`10.108.0.5`, same VPC). Frees the platform droplet's RAM; we own the PG version/extensions. (Replaces a briefly-provisioned managed DO Postgres — destroyed — at ~$9/mo less for equal perf.)

### Changes
- **docker-compose.yml** — parameterize DB host `@${POSTGRES_HOST:-postgres}:5432` so the whole fleet repoints via one env var (defaults to the local container, so this is inert without `POSTGRES_HOST` set). Also captures the human-index-v2 Spark OAuth env vars that were live on the droplet but never on main — **ends that drift**.
- **scripts/db_backup.sh** — dump **over the VPC** from `DB_HOST` via a version-pinned throwaway `postgres:18-alpine` client (instead of `docker compose exec postgres`), so backups follow the data and survive decommissioning the old container. **Fixes the backup gap:** `human_index_v2` (live!) and `for_whenever_db` were never backed up — both now included (9 DBs).
- **.env.example** — document `POSTGRES_HOST`.

### Verified
- All 9 DBs migrated row-for-row (exact, no writes in flight).
- Fleet health-green on the new DB (ieomd, humanindex, noodle, spark-swarm, umami, eshers, Matrix all 200).
- A real backup run uploaded **all 9** DBs (incl. the two formerly-missing) to Spaces, dated today.

Old compose Postgres container is **still running** as rollback (`unset POSTGRES_HOST` → `up -d`); decommission is a follow-up once soaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)